### PR TITLE
Add namespace check for Android project compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.did_change_authlocal'
+    }
+
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Added a check for the namespace property in the Android project to ensure compatibility with different Gradle versions.
Please merge this as soon as possible and release a new version. 